### PR TITLE
Fix mod downloads, install detection, and add update management

### DIFF
--- a/registry.py
+++ b/registry.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+REGISTRY_FILE = "installed_mods.json"
+
+
+class ModRegistry:
+    def __init__(self, game_path):
+        self.game_path = game_path
+        self._data = {}
+        self.load()
+
+    @property
+    def path(self):
+        return os.path.join(self.game_path, REGISTRY_FILE)
+
+    def load(self):
+        if not self.game_path:
+            self._data = {}
+            return
+        try:
+            with open(self.path, "r") as f:
+                self._data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self._data = {}
+
+    def save(self):
+        if not self.game_path:
+            return
+        os.makedirs(self.game_path, exist_ok=True)
+        with open(self.path, "w") as f:
+            json.dump(self._data, f, indent=2)
+
+    def add(self, mod_id, mod_name, file_name, file_id, file_date, class_id):
+        self._data[str(mod_id)] = {
+            "mod_name": mod_name,
+            "file_name": file_name,
+            "file_id": file_id,
+            "file_date": file_date,
+            "class_id": class_id,
+        }
+        self.save()
+
+    def remove(self, mod_id):
+        self._data.pop(str(mod_id), None)
+        self.save()
+
+    def get(self, mod_id):
+        return self._data.get(str(mod_id))
+
+    def get_all(self):
+        return dict(self._data)
+
+    def find_by_filename(self, file_name):
+        for mid, entry in self._data.items():
+            if entry.get("file_name") == file_name:
+                return mid, entry
+        return None, None

--- a/ui/components/universal_card.py
+++ b/ui/components/universal_card.py
@@ -12,7 +12,9 @@ class UniversalCard(QFrame):
             subtitle,
             icon_url=None,
             is_installed=False,
+            has_update=False,
             install_callback=None,
+            update_callback=None,
             delete_callback=None,
             click_callback=None,
             icon_char="📦",
@@ -64,14 +66,28 @@ class UniversalCard(QFrame):
             status_layout = QHBoxLayout()
             status_layout.setSpacing(6)
 
-            check_lbl = QLabel("✔")
-            check_lbl.setObjectName("SuccessLabel")
-            text_inst_lbl = QLabel("INSTALLED")
-            text_inst_lbl.setObjectName("SuccessLabel")
+            if has_update:
+                update_lbl = QLabel("UPDATE AVAILABLE")
+                update_lbl.setObjectName("WarningLabel")
+                update_lbl.setStyleSheet("color: #FFC107; font-weight: bold; font-size: 11px;")
+                status_layout.addWidget(update_lbl)
+            else:
+                check_lbl = QLabel("✔")
+                check_lbl.setObjectName("SuccessLabel")
+                text_inst_lbl = QLabel("INSTALLED")
+                text_inst_lbl.setObjectName("SuccessLabel")
+                status_layout.addWidget(check_lbl)
+                status_layout.addWidget(text_inst_lbl)
 
-            status_layout.addWidget(check_lbl)
-            status_layout.addWidget(text_inst_lbl)
             layout.addLayout(status_layout)
+
+            if has_update and update_callback:
+                update_btn = QPushButton("⬆ Update")
+                update_btn.setFixedSize(100, 36)
+                update_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+                update_btn.setObjectName("ActionBtn")
+                update_btn.clicked.connect(lambda: update_callback(update_btn))
+                layout.addWidget(update_btn)
 
             if delete_callback:
                 delete_btn = QPushButton("🗑 Uninstall")
@@ -97,11 +113,14 @@ class UniversalCard(QFrame):
             pass
 
     def mouseReleaseEvent(self, event):
-        child = self.childAt(event.position().toPoint())
-        if (
-            event.button() == Qt.MouseButton.LeftButton
-            and self.click_callback
-            and not isinstance(child, QPushButton)
-        ):
-            self.click_callback()
-        super().mouseReleaseEvent(event)
+        try:
+            child = self.childAt(event.position().toPoint())
+            if (
+                event.button() == Qt.MouseButton.LeftButton
+                and self.click_callback
+                and not isinstance(child, QPushButton)
+            ):
+                self.click_callback()
+            super().mouseReleaseEvent(event)
+        except RuntimeError:
+            pass

--- a/ui/layouts/mod_dialog.py
+++ b/ui/layouts/mod_dialog.py
@@ -7,7 +7,8 @@ from ui.workers.image_worker import ImageWorker
 
 
 class ModDetailsDialog(QDialog):
-    def __init__(self, mod_data, is_installed=False, install_callback=None, remove_callback=None, parent=None):
+    def __init__(self, mod_data, is_installed=False, has_update=False,
+                 install_callback=None, update_callback=None, remove_callback=None, parent=None):
         super().__init__(None)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.setWindowTitle(mod_data['name'])
@@ -15,8 +16,10 @@ class ModDetailsDialog(QDialog):
 
         self.mod_data = mod_data
         self.install_callback = install_callback
+        self.update_callback = update_callback
         self.remove_callback = remove_callback
         self.is_installed = is_installed
+        self.has_update = has_update
 
         layout = QVBoxLayout(self)
         layout.setSpacing(0)
@@ -234,6 +237,13 @@ class ModDetailsDialog(QDialog):
         self.action_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self.action_btn.clicked.connect(self.on_action_click)
 
+        self.update_btn = QPushButton("⬆ Update")
+        self.update_btn.setFixedSize(120, 40)
+        self.update_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.update_btn.setObjectName("ActionBtn")
+        self.update_btn.clicked.connect(self.on_update_click)
+        self.update_btn.setVisible(self.has_update and self.is_installed)
+
         close_btn = QPushButton("Close")
         close_btn.setFixedSize(100, 40)
         close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -241,6 +251,7 @@ class ModDetailsDialog(QDialog):
         close_btn.clicked.connect(self.close)
 
         footer.addWidget(self.action_btn)
+        footer.addWidget(self.update_btn)
         footer.addStretch()
         footer.addWidget(close_btn)
         layout.addLayout(footer)
@@ -269,6 +280,21 @@ class ModDetailsDialog(QDialog):
                 self.action_btn.setText("Downloading...")
                 self.action_btn.setEnabled(False)
                 self.install_callback(self.action_btn, self.on_install_finished)
+
+    def on_update_click(self):
+        if self.update_callback:
+            self.update_btn.setText("Updating...")
+            self.update_btn.setEnabled(False)
+            self.update_callback(self.update_btn, self.on_update_finished)
+
+    def on_update_finished(self, success=True):
+        if success:
+            self.has_update = False
+            self.update_btn.setVisible(False)
+        else:
+            self.update_btn.setText("⬆ Update")
+            self.update_btn.setEnabled(True)
+        self.update_action_button()
 
     def on_install_finished(self, success=True):
         if success: self.is_installed = True

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -35,7 +35,7 @@ class MainWindow(QMainWindow):
         )
         self.stack = QStackedWidget()
         self.search_page = SearchPage(self.client)
-        self.installed_page = InstalledPage()
+        self.installed_page = InstalledPage(self.client)
 
         layout.addWidget(self.sidebar)
         self.stack.addWidget(self.search_page)
@@ -61,6 +61,9 @@ class MainWindow(QMainWindow):
 
         if hasattr(self, 'search_page'):
             self.search_page.update_client(self.client)
+
+        if hasattr(self, 'installed_page'):
+            self.installed_page.update_client(self.client)
 
         self.init_worker = InitWorker(self.client)
         self.init_worker.finished.connect(lambda msg: print(f"API: {msg}"))

--- a/ui/pages/installed_page.py
+++ b/ui/pages/installed_page.py
@@ -1,20 +1,32 @@
+import json
 import os
 import shutil
 from datetime import datetime
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QLabel, QPushButton, QScrollArea, QMessageBox, QFrame
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QScrollArea, QMessageBox, QFrame
 )
 from PySide6.QtCore import Qt
 
 from ui.common.maps import PATH_MAP
 from ui.components.universal_card import UniversalCard
 from ui.layouts.mod_dialog import ModDetailsDialog
+from ui.workers import DownloadWorker, UpdateCheckWorker
+from registry import ModRegistry
+
 
 class InstalledPage(QWidget):
-    def __init__(self):
+    def __init__(self, client):
         super().__init__()
+        self.client = client
         self.game_path = ""
+        self.registry = ModRegistry("")
+        self.available_updates = {}
+        self._update_queue = []
         self.setup_ui()
+
+    def update_client(self, client):
+        self.client = client
 
     def setup_ui(self):
         layout = QVBoxLayout(self)
@@ -25,10 +37,35 @@ class InstalledPage(QWidget):
         title.setObjectName("Title")
         layout.addWidget(title)
 
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(10)
+
         refresh_btn = QPushButton("Refresh List")
         refresh_btn.setFixedWidth(120)
         refresh_btn.clicked.connect(self.refresh)
-        layout.addWidget(refresh_btn)
+        btn_row.addWidget(refresh_btn)
+
+        self.check_btn = QPushButton("Check for Updates")
+        self.check_btn.setFixedWidth(160)
+        self.check_btn.setObjectName("ActionBtn")
+        self.check_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.check_btn.clicked.connect(self.check_updates)
+        btn_row.addWidget(self.check_btn)
+
+        self.update_all_btn = QPushButton("Update All")
+        self.update_all_btn.setFixedWidth(120)
+        self.update_all_btn.setObjectName("ActionBtn")
+        self.update_all_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.update_all_btn.clicked.connect(self.update_all)
+        self.update_all_btn.setVisible(False)
+        btn_row.addWidget(self.update_all_btn)
+
+        self.status_label = QLabel("")
+        self.status_label.setObjectName("DimLabel")
+        btn_row.addWidget(self.status_label)
+
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
@@ -48,7 +85,57 @@ class InstalledPage(QWidget):
 
     def set_game_path(self, path):
         self.game_path = os.path.normpath(path) if path else ""
+        self.registry = ModRegistry(self.game_path)
+        self.available_updates = {}
+        self.update_all_btn.setVisible(False)
+        self.status_label.setText("")
         self.refresh()
+
+    def check_updates(self):
+        if not self.game_path:
+            QMessageBox.warning(self, "Error", "Set game folder first!")
+            return
+
+        entries = self.registry.get_all()
+        if not entries:
+            self.status_label.setText("No registered mods to check.")
+            return
+
+        self.check_btn.setText("Checking...")
+        self.check_btn.setEnabled(False)
+        self.status_label.setText("")
+        self.update_all_btn.setVisible(False)
+
+        self.check_worker = UpdateCheckWorker(self.client, self.registry)
+        self.check_worker.progress.connect(self._on_check_progress)
+        self.check_worker.finished.connect(self._on_check_finished)
+        self.check_worker.error.connect(self._on_check_error)
+        self.check_worker.start()
+
+    def _on_check_progress(self, current, total):
+        self.status_label.setText(f"Checking {current}/{total}...")
+
+    def _on_check_finished(self, result_json):
+        self.check_btn.setText("Check for Updates")
+        self.check_btn.setEnabled(True)
+
+        self.available_updates = json.loads(result_json)
+        count = len(self.available_updates)
+
+        if count > 0:
+            self.status_label.setText(f"{count} update(s) available")
+            self.update_all_btn.setText(f"Update All ({count})")
+            self.update_all_btn.setVisible(True)
+        else:
+            self.status_label.setText("All mods are up to date.")
+            self.update_all_btn.setVisible(False)
+
+        self.refresh()
+
+    def _on_check_error(self, msg):
+        self.check_btn.setText("Check for Updates")
+        self.check_btn.setEnabled(True)
+        self.status_label.setText(f"Error: {msg}")
 
     def refresh(self):
         self.clear_list()
@@ -92,20 +179,29 @@ class InstalledPage(QWidget):
                         size_mb = os.path.getsize(full_path) / (1024 * 1024)
                         icon = "📦"
 
+                    mod_id_str, reg_entry = self.registry.find_by_filename(name)
+                    has_update = mod_id_str is not None and mod_id_str in self.available_updates
+
                     fake_data = {
-                        'name': name,
+                        'name': reg_entry.get('mod_name', name) if reg_entry else name,
                         'authors': [{'name': 'Local File'}],
                         'summary': f"Location: {rel_path}",
                         'classId': class_id
                     }
 
                     card = UniversalCard(
-                        title=name,
+                        title=fake_data['name'],
                         subtitle=f"{size_mb:.2f} MB  •  {created}",
                         is_installed=True,
-                        delete_callback=lambda p=rel_path: self.delete_file(p),
-                        click_callback=lambda d=fake_data, p=rel_path: ModDetailsDialog(
-                            d, is_installed=True, remove_callback=lambda: self.delete_file(p), parent=self
+                        has_update=has_update,
+                        update_callback=(
+                            lambda btn, mid=mod_id_str: self.update_single(mid, btn)
+                        ) if has_update else None,
+                        delete_callback=lambda p=rel_path, mid=mod_id_str: self.delete_file(p, mod_id=mid),
+                        click_callback=lambda d=fake_data, p=rel_path, mid=mod_id_str: ModDetailsDialog(
+                            d, is_installed=True,
+                            remove_callback=lambda: self.delete_file(p, mod_id=mid),
+                            parent=self
                         ).exec(),
                         icon_char=icon
                     )
@@ -116,8 +212,154 @@ class InstalledPage(QWidget):
         if not found_any:
             self.layout_content.addWidget(QLabel("No installed content found."))
 
+    def update_single(self, mod_id_str, btn=None):
+        mod_id = int(mod_id_str)
+        reg_entry = self.registry.get(mod_id)
+        if not reg_entry:
+            return
+
+        old_name = reg_entry.get('file_name', '')
+        class_id = reg_entry.get('class_id')
+        subfolder = PATH_MAP.get(class_id, "UserData/Mods")
+        target_dir = os.path.normpath(os.path.join(self.game_path, subfolder))
+
+        old_path = os.path.join(target_dir, old_name)
+        if os.path.exists(old_path):
+            if os.path.isdir(old_path):
+                shutil.rmtree(old_path)
+            else:
+                os.remove(old_path)
+
+        if btn and hasattr(btn, "setText"):
+            btn.setText("Updating...")
+            btn.setEnabled(False)
+
+        is_zip = (class_id == 9184)
+        self.dl_worker = DownloadWorker(self.client, mod_id, target_dir, is_zip)
+
+        def on_done(result_json):
+            result = json.loads(result_json)
+            self.registry.add(
+                mod_id=mod_id,
+                mod_name=reg_entry.get('mod_name', ''),
+                file_name=result.get('file_name', ''),
+                file_id=result.get('file_id'),
+                file_date=result.get('file_date', ''),
+                class_id=class_id,
+            )
+            self.available_updates.pop(mod_id_str, None)
+            remaining = len(self.available_updates)
+            if remaining > 0:
+                self.update_all_btn.setText(f"Update All ({remaining})")
+            else:
+                self.update_all_btn.setVisible(False)
+                self.status_label.setText("All mods are up to date.")
+
+            if self._update_queue:
+                next_id = self._update_queue.pop(0)
+                self.update_single(next_id)
+            else:
+                self.refresh()
+
+        def on_error(msg):
+            print(f"[UPDATE ERROR] mod {mod_id_str}: {msg}")
+            if self._update_queue:
+                next_id = self._update_queue.pop(0)
+                self.update_single(next_id)
+            else:
+                self.refresh()
+
+        self.dl_worker.finished.connect(on_done)
+        self.dl_worker.error.connect(on_error)
+        self.dl_worker.start()
+
+    def update_all(self):
+        if not self.available_updates:
+            return
+
+        ids = list(self.available_updates.keys())
+        self.update_all_btn.setEnabled(False)
+        self.update_all_btn.setText("Updating...")
+        self.status_label.setText(f"Updating 0/{len(ids)}...")
+
+        self._update_queue = ids[1:]
+        self._update_total = len(ids)
+        self._update_done = 0
+
+        def tracked_update(mid_str, btn=None):
+            mod_id = int(mid_str)
+            reg_entry = self.registry.get(mod_id)
+            if not reg_entry:
+                if self._update_queue:
+                    next_id = self._update_queue.pop(0)
+                    tracked_update(next_id)
+                else:
+                    self._finish_update_all()
+                return
+
+            old_name = reg_entry.get('file_name', '')
+            class_id = reg_entry.get('class_id')
+            subfolder = PATH_MAP.get(class_id, "UserData/Mods")
+            target_dir = os.path.normpath(os.path.join(self.game_path, subfolder))
+
+            old_path = os.path.join(target_dir, old_name)
+            if os.path.exists(old_path):
+                if os.path.isdir(old_path):
+                    shutil.rmtree(old_path)
+                else:
+                    os.remove(old_path)
+
+            is_zip = (class_id == 9184)
+            self.dl_worker = DownloadWorker(self.client, mod_id, target_dir, is_zip)
+
+            def on_done(result_json):
+                result = json.loads(result_json)
+                self.registry.add(
+                    mod_id=mod_id,
+                    mod_name=reg_entry.get('mod_name', ''),
+                    file_name=result.get('file_name', ''),
+                    file_id=result.get('file_id'),
+                    file_date=result.get('file_date', ''),
+                    class_id=class_id,
+                )
+                self.available_updates.pop(mid_str, None)
+                self._update_done += 1
+                self.status_label.setText(f"Updating {self._update_done}/{self._update_total}...")
+
+                if self._update_queue:
+                    next_id = self._update_queue.pop(0)
+                    tracked_update(next_id)
+                else:
+                    self._finish_update_all()
+
+            def on_error(msg):
+                print(f"[UPDATE ALL ERROR] mod {mid_str}: {msg}")
+                self._update_done += 1
+                self.status_label.setText(f"Updating {self._update_done}/{self._update_total}...")
+                if self._update_queue:
+                    next_id = self._update_queue.pop(0)
+                    tracked_update(next_id)
+                else:
+                    self._finish_update_all()
+
+            self.dl_worker.finished.connect(on_done)
+            self.dl_worker.error.connect(on_error)
+            self.dl_worker.start()
+
+        tracked_update(ids[0])
+
+    def _finish_update_all(self):
+        self.update_all_btn.setEnabled(True)
+        remaining = len(self.available_updates)
+        if remaining > 0:
+            self.update_all_btn.setText(f"Update All ({remaining})")
+            self.status_label.setText(f"{remaining} update(s) remaining.")
+        else:
+            self.update_all_btn.setVisible(False)
+            self.status_label.setText("All mods updated.")
+        self.refresh()
+
     def get_dir_size(self, path):
-        """Calculates total MB of a folder by summing its files."""
         total = 0
         try:
             for dirpath, dirnames, filenames in os.walk(path):
@@ -128,7 +370,7 @@ class InstalledPage(QWidget):
             return 0
         return total / (1024 * 1024)
 
-    def delete_file(self, relative_path):
+    def delete_file(self, relative_path, mod_id=None):
         full_path = os.path.normpath(os.path.join(self.game_path, relative_path))
         filename = os.path.basename(relative_path)
 
@@ -140,6 +382,8 @@ class InstalledPage(QWidget):
                         shutil.rmtree(full_path)
                     else:
                         os.remove(full_path)
+                if mod_id:
+                    self.registry.remove(int(mod_id))
                 self.refresh()
                 return True
             except Exception as e:


### PR DESCRIPTION
## Summary

- **Fix mods failing to download** when CurseForge returns `null` for `downloadUrl` (e.g. mod ID 1429532 / ATK Tool). Added fallback via `/mods/{id}/files/{fileId}/download-url` endpoint and CDN URL construction.
- **Fix install status not reflecting correctly** for some mods. Replaced fragile filename substring matching with an `installed_mods.json` registry that tracks mods by their CurseForge ID. The old filesystem fallback is kept for mods installed before the registry existed, with deduplication to prevent two mods with similar names both showing as installed.
- **Add update detection and management**. The registry stores the installed `file_id` and compares it against the latest available version from the API. Update buttons appear on search results, mod detail dialogs, and the installed files page.
- **Add "Check for Updates" / "Update All" to the Installed page** with per-mod individual update buttons and progress feedback.
- **Show download errors** to the user via dialog instead of silently failing.
- **Fix intermittent crash** caused by `RuntimeError` when a card widget is clicked during a list refresh.

## Test plan

- [x] Search for mod ID 1429532 (ATK Tool) and verify it downloads successfully
- [x] After downloading a mod, verify "INSTALLED" status appears immediately on the search page
- [x] Close and reopen the app — verify installed status persists
- [x] Search for mods with similar names and verify only the actually installed one shows as installed
- [x] Go to Installed Files page, click "Check for Updates", verify progress and results
- [x] Click individual "Update" button on a mod with an update available
- [x] Uninstall a mod and verify it is removed from both disk and registry
- [x] Click "Update All" and verify all outdated mods update sequentially
